### PR TITLE
Allow the render method on TableColumn to return a `null` value

### DIFF
--- a/typings/rendition.d.ts
+++ b/typings/rendition.d.ts
@@ -364,7 +364,7 @@ declare module 'rendition' {
 		icon?: string;
 		label?: string | JSX.Element;
 		sortable?: boolean | TableSortFunction;
-		render?: (value: any, row: T) => string | JSX.Element;
+		render?: (value: any, row: T) => string | JSX.Element | null;
 	}
 
 	interface TableProps<T> {


### PR DESCRIPTION
Fixes to #302

change-type: minor