### PR TITLE
fix(Stories): Change onPress to onClick

### DIFF
--- a/src/stories/Button.js
+++ b/src/stories/Button.js
@@ -17,22 +17,22 @@ storiesOf('Core/Button', module)
   .add('Standard', () => {
     return (
       <Container>
-        <Button m={2} primary onPress={action('case-1')}>
+        <Button m={2} primary onClick={action('case-1')}>
           Primary
         </Button>
-        <Button m={2} secondary onPress={action('case-2')}>
+        <Button m={2} secondary onClick={action('case-2')}>
           Secondary
         </Button>
-        <Button m={2} tertiary onPress={action('case-3')}>
+        <Button m={2} tertiary onClick={action('case-3')}>
           Tertiary
         </Button>
-        <Button m={2} success onPress={action('case-4')}>
+        <Button m={2} success onClick={action('case-4')}>
           Success
         </Button>
-        <Button m={2} danger onPress={action('case-5')}>
+        <Button m={2} danger onClick={action('case-5')}>
           Danger
         </Button>
-        <Button m={2} onPress={action('case-6')}>
+        <Button m={2} onClick={action('case-6')}>
           Default
         </Button>
       </Container>
@@ -41,22 +41,22 @@ storiesOf('Core/Button', module)
   .add('Emphasized', () => {
     return (
       <Container>
-        <Button m={2} emphasized primary onPress={action('case-1')}>
+        <Button m={2} emphasized primary onClick={action('case-1')}>
           Primary
         </Button>
-        <Button m={2} emphasized secondary onPress={action('case-2')}>
+        <Button m={2} emphasized secondary onClick={action('case-2')}>
           Secondary
         </Button>
-        <Button m={2} emphasized tertiary onPress={action('case-3')}>
+        <Button m={2} emphasized tertiary onClick={action('case-3')}>
           Tertiary
         </Button>
-        <Button m={2} emphasized success onPress={action('case-4')}>
+        <Button m={2} emphasized success onClick={action('case-4')}>
           Success
         </Button>
-        <Button m={2} emphasized danger onPress={action('case-5')}>
+        <Button m={2} emphasized danger onClick={action('case-5')}>
           Danger
         </Button>
-        <Button m={2} emphasized onPress={action('case-6')}>
+        <Button m={2} emphasized onClick={action('case-6')}>
           Default
         </Button>
       </Container>
@@ -65,22 +65,22 @@ storiesOf('Core/Button', module)
   .add('Disabled', () => {
     return (
       <Container>
-        <Button m={2} disabled primary onPress={action('case-1')}>
+        <Button m={2} disabled primary onClick={action('case-1')}>
           Primary
         </Button>
-        <Button m={2} disabled secondary onPress={action('case-2')}>
+        <Button m={2} disabled secondary onClick={action('case-2')}>
           Secondary
         </Button>
-        <Button m={2} disabled tertiary onPress={action('case-3')}>
+        <Button m={2} disabled tertiary onClick={action('case-3')}>
           Tertiary
         </Button>
-        <Button m={2} disabled success onPress={action('case-4')}>
+        <Button m={2} disabled success onClick={action('case-4')}>
           Success
         </Button>
-        <Button m={2} disabled danger onPress={action('case-5')}>
+        <Button m={2} disabled danger onClick={action('case-5')}>
           Danger
         </Button>
-        <Button m={2} disabled onPress={action('case-6')}>
+        <Button m={2} disabled onClick={action('case-6')}>
           Default
         </Button>
       </Container>
@@ -89,22 +89,22 @@ storiesOf('Core/Button', module)
   .add('Outline', () => {
     return (
       <Container>
-        <Button m={2} outline primary onPress={action('case-1')}>
+        <Button m={2} outline primary onClick={action('case-1')}>
           Primary
         </Button>
-        <Button m={2} outline secondary onPress={action('case-2')}>
+        <Button m={2} outline secondary onClick={action('case-2')}>
           Secondary
         </Button>
-        <Button m={2} outline tertiary onPress={action('case-3')}>
+        <Button m={2} outline tertiary onClick={action('case-3')}>
           Tertiary
         </Button>
-        <Button m={2} outline success onPress={action('case-4')}>
+        <Button m={2} outline success onClick={action('case-4')}>
           Success
         </Button>
-        <Button m={2} outline danger onPress={action('case-5')}>
+        <Button m={2} outline danger onClick={action('case-5')}>
           Danger
         </Button>
-        <Button m={2} outline onPress={action('case-6')}>
+        <Button m={2} outline onClick={action('case-6')}>
           Default
         </Button>
       </Container>
@@ -113,10 +113,10 @@ storiesOf('Core/Button', module)
   .add('Underline', () => {
     return (
       <Container>
-        <Button m={2} primary underline onPress={action('case-1')}>
+        <Button m={2} primary underline onClick={action('case-1')}>
           Button
         </Button>
-        <Button m={2} underline onPress={action('case-1')}>
+        <Button m={2} underline onClick={action('case-1')}>
           Button
         </Button>
       </Container>
@@ -125,7 +125,7 @@ storiesOf('Core/Button', module)
   .add('Plaintext', () => {
     return (
       <Container>
-        <Button m={2} plaintext primary onPress={action('case-1')}>
+        <Button m={2} plaintext primary onClick={action('case-1')}>
           Button
         </Button>
         <Button
@@ -133,7 +133,7 @@ storiesOf('Core/Button', module)
           plaintext
           primary
           iconElement={<FaSpinner />}
-          onPress={action('case-2')}
+          onClick={action('case-2')}
         >
           Button
         </Button>
@@ -143,17 +143,17 @@ storiesOf('Core/Button', module)
   .add('Width', () => {
     return (
       <Container>
-        <Button w={95} m={2} primary onPress={action('case-1')}>
+        <Button w={95} m={2} primary onClick={action('case-1')}>
           Button
         </Button>
-        <Button w={60} m={2} secondary onPress={action('case-2')}>
+        <Button w={60} m={2} secondary onClick={action('case-2')}>
           Button
         </Button>
-        <Button w={120} m={2} tertiary onPress={action('case-3')}>
+        <Button w={120} m={2} tertiary onClick={action('case-3')}>
           Button
         </Button>
         <div style={{ width: 300 }}>
-          <Button w='100%' m={2} onPress={action('case-4')}>
+          <Button w='100%' m={2} onClick={action('case-4')}>
             Button
           </Button>
         </div>
@@ -163,10 +163,10 @@ storiesOf('Core/Button', module)
   .add('Square', () => {
     return (
       <Container>
-        <Button m={2} tertiary square onPress={action('case-3')}>
+        <Button m={2} tertiary square onClick={action('case-3')}>
           <FaExpand />
         </Button>
-        <Button m={2} square onPress={action('case-4')}>
+        <Button m={2} square onClick={action('case-4')}>
           <FaRecycle />
         </Button>
       </Container>
@@ -175,10 +175,10 @@ storiesOf('Core/Button', module)
   .add('Square Emphasized', () => {
     return (
       <Container>
-        <Button m={2} emphasized tertiary square onPress={action('case-3')}>
+        <Button m={2} emphasized tertiary square onClick={action('case-3')}>
           <FaExpand />
         </Button>
-        <Button m={2} emphasized square onPress={action('case-4')}>
+        <Button m={2} emphasized square onClick={action('case-4')}>
           <FaRecycle />
         </Button>
       </Container>

--- a/src/stories/Tooltip.js
+++ b/src/stories/Tooltip.js
@@ -28,7 +28,7 @@ storiesOf('Core/Tooltips', module)
           tooltip='Tooltip on top'
           m={2}
           primary
-          onPress={action('case-1')}
+          onClick={action('case-1')}
         >
           Tooltip on top
         </Button>
@@ -36,7 +36,7 @@ storiesOf('Core/Tooltips', module)
           tooltip={{ text: 'Tooltip on right', placement: 'right' }}
           m={2}
           secondary
-          onPress={action('case-2')}
+          onClick={action('case-2')}
         >
           Tooltip on right
         </Button>
@@ -44,7 +44,7 @@ storiesOf('Core/Tooltips', module)
           tooltip={{ text: 'Tooltip on bottom', placement: 'bottom' }}
           m={2}
           success
-          onPress={action('case-3')}
+          onClick={action('case-3')}
         >
           Tooltip on bottom
         </Button>
@@ -52,14 +52,14 @@ storiesOf('Core/Tooltips', module)
           tooltip={{ text: 'Tooltip on left', placement: 'left' }}
           m={2}
           tertiary
-          onPress={action('case-4')}
+          onClick={action('case-4')}
         >
           Tooltip on left
         </Button>
         <Button
           tooltip='Tooltip on disabled button'
           m={2}
-          onPress={action('case-5')}
+          onClick={action('case-5')}
           disabled
         >
           Tooltip on disabled button
@@ -74,7 +74,7 @@ storiesOf('Core/Tooltips', module)
           tooltip={{ text: 'Tooltip on top', trigger: 'click' }}
           m={2}
           primary
-          onPress={action('case-1')}
+          onClick={action('case-1')}
         >
           Tooltip on top
         </Button>
@@ -86,7 +86,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           secondary
-          onPress={action('case-2')}
+          onClick={action('case-2')}
         >
           Tooltip on right
         </Button>
@@ -98,7 +98,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           success
-          onPress={action('case-3')}
+          onClick={action('case-3')}
         >
           Tooltip on bottom
         </Button>
@@ -110,7 +110,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           tertiary
-          onPress={action('case-4')}
+          onClick={action('case-4')}
         >
           Tooltip on left
         </Button>
@@ -204,7 +204,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           primary
-          onPress={action('case-1')}
+          onClick={action('case-1')}
         >
           Styled tooltip container
         </Button>
@@ -219,7 +219,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           primary
-          onPress={action('case-1')}
+          onClick={action('case-1')}
         >
           Styled tooltip arrow
         </Button>
@@ -233,7 +233,7 @@ storiesOf('Core/Tooltips', module)
           }}
           m={2}
           primary
-          onPress={action('case-1')}
+          onClick={action('case-1')}
         >
           Styled tooltip inner
         </Button>

--- a/src/stories/deprecated/DeleteButton.js
+++ b/src/stories/deprecated/DeleteButton.js
@@ -10,5 +10,5 @@ const Container = styled.div`
 storiesOf('Deprecated/DeleteButton', module)
   .addDecorator(story => <Container>{story()}</Container>)
   .add('Standard', () => {
-    return <DeleteButton onPress={action('DeleteButton clicked')} />
+    return <DeleteButton onClick={action('DeleteButton clicked')} />
   })


### PR DESCRIPTION
Fixes #535

`onPress` is intended for use in react native and doesn't work in
a browser environment.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>