### PR TITLE
Change Progress Bar background

### DIFF
--- a/__tests__/components/__snapshots__/ProgressBar.spec.js.snap
+++ b/__tests__/components/__snapshots__/ProgressBar.spec.js.snap
@@ -5,7 +5,7 @@ exports[`ProgressBar renders correctly 1`] = `
   className="sc-bdVaJa jKopLr"
 >
   <div
-    className="sc-gZMcBi cmZZgb sc-iwsKbI eoQbrg"
+    className="sc-gZMcBi cmZZgb sc-iwsKbI ggJERy"
     type={undefined}
   >
     <div

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -47,7 +47,7 @@ const Sleeve = styled.div`
     px(props.emphasized ? props.theme.space[4] : props.theme.space[3])};
   line-height: ${props =>
     px(props.emphasized ? props.theme.space[4] : props.theme.space[3])};
-  background: ${props => props.theme.colors.gray.light};
+  background: ${props => props.theme.colors.quartenary.main};
   font-size: ${props => (props.emphasized ? 1 : 0.6)}em;
   overflow: hidden;
 `


### PR DESCRIPTION
from gray.light to quartenary.main
Change-type: patch
Signed-off-by: amdomanska <aga@resin.io>
connects-to: #537

![image](https://user-images.githubusercontent.com/8298769/44655320-f443d280-a9f4-11e8-841d-a7b44226e072.png)
