### PR TITLE
Table: Add right padding

### DIFF
--- a/__tests__/components/__snapshots__/Table.spec.js.snap
+++ b/__tests__/components/__snapshots__/Table.spec.js.snap
@@ -5,7 +5,7 @@ exports[`Table component should match the stored snapshot 1`] = `
   className="sc-bdVaJa jKopLr"
 >
   <div
-    className="sc-jTzLTM gnDJTX"
+    className="sc-jTzLTM cABfIm"
   >
     <div
       data-display="table-head"

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -39,7 +39,8 @@ const BaseTable = styled.div`
 			> [data-display='table-cell'] {
 				display: table-cell;
 				text-align: left;
-				padding-left: 40px;
+				padding-left: 20px;
+				padding-right: 20px;
 				padding-top: 10px;
 				padding-bottom: 10px;
 				font-size: 16px;
@@ -61,7 +62,8 @@ const BaseTable = styled.div`
 				text-align: left;
 				padding-top: 14px;
 				padding-bottom: 14px;
-				padding-left: 40px;
+				padding-left: 20px;
+				padding-right: 20px;
 				text-decoration: none;
 				color: inherit;
 			}


### PR DESCRIPTION
Add right padding and adjust left padding to maintain table layout

Resolves: #384
Change-type: patch
Signed-off-by: amdomanska <aga@resin.io>

Previously:
![tableprev](https://user-images.githubusercontent.com/8298769/44721159-48b88200-aac9-11e8-8b5a-d270e2e1cb3f.png)
![tableprevinspect](https://user-images.githubusercontent.com/8298769/44721162-4b1adc00-aac9-11e8-8ca5-030502967c96.png)

Now:
![tablenow](https://user-images.githubusercontent.com/8298769/44721171-51a95380-aac9-11e8-8e55-4ab6b638599e.png)
![tablenowinspect](https://user-images.githubusercontent.com/8298769/44721177-54a44400-aac9-11e8-9ad2-963dcc71d88a.png)

