### PR TITLE
DropdownButton: Align arrow toggle properly

### DIFF
--- a/__tests__/components/__snapshots__/BadgeSelect.spec.js.snap
+++ b/__tests__/components/__snapshots__/BadgeSelect.spec.js.snap
@@ -12,7 +12,7 @@ exports[`BadgeSelect renders correctly 1`] = `
       onClick={[Function]}
     >
       <div
-        className="sc-gZMcBi cmZZgb sc-dnqmqq eheJhs sc-htoDjs frbeoW"
+        className="sc-gZMcBi cmZZgb sc-dnqmqq eheJhs sc-htoDjs iZSBOM"
       >
         <div
           className="sc-gqjmRU iMncXr sc-iwsKbI khHCQa sc-gzVnrw gceidV"

--- a/__tests__/components/__snapshots__/Filters.spec.js.snap
+++ b/__tests__/components/__snapshots__/Filters.spec.js.snap
@@ -90,7 +90,7 @@ exports[`Filters component should match the stored snapshot 1`] = `
             onClick={[Function]}
           >
             <div
-              className="sc-jKJlTe dCeOjK sc-dxgOiQ dtwKdh sc-kpOJdX kGHtPs"
+              className="sc-jKJlTe dCeOjK sc-dxgOiQ dtwKdh sc-kpOJdX jwZFw"
             >
               <div
                 className="sc-eNQAEJ tjatD sc-ckVGcZ bTbrkH sc-kGXeez cazHBK"

--- a/src/components/DropDownButton.js
+++ b/src/components/DropDownButton.js
@@ -85,7 +85,7 @@ const Toggle = ({ open, handler, label, joined, ...props }) => {
     if (label) {
       return (
         <JoinedButton {...props} pl={16} pr={0} onClick={handler}>
-          <Flex justify='space-between'>
+          <Flex justify='space-between' align='center'>
             <Box mt='1px'>{label}</Box>
             <IconWrapper>
               {open ? <IconCaretUp /> : <IconCaretDown />}


### PR DESCRIPTION
Align arrow toggle vertically on center
even if the button lable consists of multiple lines

Resolves: #553
Change-type: patch
Signed-off-by: amdomanska <aga@resin.io>

result:
![ddbuttonnow](https://user-images.githubusercontent.com/8298769/44779985-2b46ef00-ab81-11e8-8843-4c806c9806a9.png)
