### PR TITLE
table: Remove Box wrapper

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -19,7 +19,6 @@ import styled from 'styled-components';
 
 import theme from '../theme';
 import Button from './Button';
-import { Box } from './Grid';
 import Pager from './Pager';
 
 const highlightStyle = `
@@ -439,7 +438,7 @@ export default class Table<T> extends React.Component<
 		const sortedData = this.sortData(data).slice(lowerBound, upperBound);
 
 		return (
-			<Box {...props}>
+			<>
 				{!!usePager &&
 					(_pagerPosition === 'top' || _pagerPosition === 'both') && (
 						<Pager
@@ -543,7 +542,7 @@ export default class Table<T> extends React.Component<
 							mb={2}
 						/>
 					)}
-			</Box>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
Connects-to: #583
Change-type: patch
Signed-off-by: Dimitrios Lytras <dimitrios@resin.io>

It would be better for the parent element to decide on the sizing of the Table, than having an extra dom node in between. 
It's also a bit of a problem when combined with the `TableWithCustomColumns` wrapper in the UI.