### PR TITLE
fix(Flex): Normalize props passed to Flex base component

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,5 +1,6 @@
 import { Box as _Box, Flex as _Flex } from 'grid-styled';
-import { compose } from 'recompose';
+import * as React from 'react';
+import { compose, withProps } from 'recompose';
 import { BoxProps, FlexProps } from 'rendition';
 import styled from 'styled-components';
 import { color, fontSize } from 'styled-system';
@@ -13,9 +14,25 @@ const BoxBase = styled(_Box)`
 	${fontSize} ${color};
 `;
 
-export const Flex = compose(asRendition)(FlexBase) as React.ComponentClass<
-	FlexProps
->;
+const normalizeProps = withProps(
+	({ align, justify, wrap, ...props }: FlexProps) => {
+		if (align || justify || wrap) {
+			console.warn(
+				'The align, justify and wrap properties are deprecated and will be removed in rendition v5. Please use alignItems, justifyContent and flexWrap instead.',
+			);
+		}
+		return {
+			alignItems: align,
+			justifyContent: justify,
+			flexWrap: wrap,
+			...props,
+		};
+	},
+);
+
+export const Flex = compose(asRendition, normalizeProps)(
+	FlexBase,
+) as React.ComponentClass<FlexProps>;
 export const Box = compose(asRendition)(BoxBase) as React.ComponentClass<
 	BoxProps
 >;

--- a/src/stories/Flex.js
+++ b/src/stories/Flex.js
@@ -23,7 +23,7 @@ storiesOf('Core/Flex', module)
     return (
       <Provider>
         <Box m={3}>
-          <Flex justify='space-between'>
+          <Flex justifyContent='space-between'>
             <Box style={{ height: 200, width: 200 }} bg='red' />
             <Box style={{ height: 200, width: 200 }} bg='blue' />
             <Box style={{ height: 200, width: 200 }} bg='green' />

--- a/src/stories/README/Flex.md
+++ b/src/stories/README/Flex.md
@@ -8,9 +8,9 @@ Displays an element using [flexbox](1).
 
 | Name          | Type      | Default   | Required   | Description                                          |
 | --------------------------------------------------------------------------------------------------------- |
-| `align`      | <code>string &#124; string[]</code> | - | - | Sets `align-items`, if the value is an array, sets a responsive style corresponding to the theme's breakpoints
-| `justify`      | <code>string &#124; string[]</code> | - | - | Sets `justify-content`, if the value is an array, sets a responsive style corresponding to the theme's breakpoints
+| `alignItems`      | <code>string &#124; string[]</code> | - | - | Sets `align-items`, if the value is an array, sets a responsive style corresponding to the theme's breakpoints
+| `justifyContent`      | <code>string &#124; string[]</code> | - | - | Sets `justify-content`, if the value is an array, sets a responsive style corresponding to the theme's breakpoints
 | `flexDirection`      | <code>string &#124; string[]</code> | - | - | Sets `flex-direction`, if the value is an array, sets a responsive style corresponding to the theme's breakpoints
-| `wrap`      | <code>string &#124; string[]</code> | - | - | Sets `flex-wrap: wrap`
+| `flexWrap`      | <code>string &#124; string[]</code> | - | - | Sets `flex-wrap: wrap`
 
 [1]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox

--- a/typings/rendition.d.ts
+++ b/typings/rendition.d.ts
@@ -274,9 +274,12 @@ declare module 'rendition' {
 
 	interface FlexProps extends BoxProps {
 		align?: string | string[];
+		alignItems?: string | string[];
 		justify?: string | string[];
+		justifyContent?: string | string[];
 		flexDirection?: string | string[];
 		wrap?: boolean | boolean[] | string;
+		flexWrap?: boolean | boolean[] | string;
 	}
 
 	class Flex extends RenderableElementWithProps<FlexProps, any> {}


### PR DESCRIPTION
In some instances grid-styled will use the incorrect version of
styled-system, resulting in Flex props not working properly.
A deprecation notice has been added, and in v5 the new props will become
standard.

Change-type: minor
Signed-off-by: Lucian Buzzo <lucian@resin.io>