### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13468,9 +13468,9 @@
       }
     },
     "resin-semver": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/resin-semver/-/resin-semver-1.3.0.tgz",
-      "integrity": "sha512-3448TCpZk6Ehm1Bo3ag7WPmEXz62YaWppKGiDC834m9cs31eSkamj45Y5RqKGr7R8Q1WKp12Wm2xitxiJiO12w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resin-semver/-/resin-semver-1.4.0.tgz",
+      "integrity": "sha512-7hvdM8waBxJiZcV7wqvCGG4SPp+PNpg43A6PCwiJTIIw07TgP4+/tlTmumT1MpSOn5o+w/0lt8wc3dJSsItwPQ==",
       "requires": {
         "@types/lodash.memoize": "^4.1.2",
         "@types/semver": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "recompose": "0.26.0",
     "regex-parser": "^2.2.7",
     "resin-device-status": "^1.1.1",
-    "resin-semver": "^1.3.0",
+    "resin-semver": "^1.4.0",
     "showdown": "^1.7.3",
     "styled-components": "^3.2.3",
     "styled-system": "^1.0.5",


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)